### PR TITLE
Update _preview.scss to wrap long words (words without whitespaces)

### DIFF
--- a/src/sass/_preview.scss
+++ b/src/sass/_preview.scss
@@ -98,6 +98,7 @@
     }
 
     .preview__self-summary {
+      overflow-wrap: break-word;
       margin-top: 8px;
       font-size: 12.25px;
     }


### PR DESCRIPTION
I think you should add this style to "summary about yourself" section to wrap the long words:

overflow-wrap: break-word;

Without it, the print view could be unreadable.
Now I checked only this section, maybe other sections need also the same style.